### PR TITLE
docs(skills): 冗長な記述を削減（docs のタグ再説明・issue のセルフチェック復唱）

### DIFF
--- a/ai-agent-configs/skills/docs/SKILL.md
+++ b/ai-agent-configs/skills/docs/SKILL.md
@@ -51,8 +51,6 @@ note/{date}-{title}.md          # repoに紐づかない
 - `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
 - `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
 
-`ccs/*` は計算機分野、`ndc/*` は汎用知識、`tech/*` は実体（ツール+概念）。
-
 例: Hono の認証ミドルウェア比較ノートを永続化する場合
 
 ```yaml

--- a/ai-agent-configs/skills/issue/SKILL.md
+++ b/ai-agent-configs/skills/issue/SKILL.md
@@ -130,16 +130,11 @@ APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [
 
 ## セルフチェック
 
+手順に従えば満たされる項目は挙げない。判断を伴い漏れやすいもののみ:
+
 ```
-□ 類似issue/PRを open/closed 両方検索したか？
 □ 近接duplicate発見時にユーザーへ判断を仰いだか？
-□ CONTRIBUTING / CODE_OF_CONDUCT / SUPPORT を確認したか？
-□ template必須フィールドを埋めたか？
-□ 主張・修正内容にインライン出典を付けたか？
-□ 出典なしの情報に（未検証）を付けたか？
+□ community guidelines（CONTRIBUTING / CODE_OF_CONDUCT / SUPPORT）に抵触していないか？
 □ 1 issue = 1 concern か？
-□ draft を docs skill の規約で vault に保存したか？
 □ ユーザ確認を取ってから投稿したか？
-□ 投稿後、draft末尾にissue URLを追記したか？
-□ sub-issue紐付けの要否を判断したか？
 ```

--- a/dot_claude/exact_skills/docs/SKILL.md
+++ b/dot_claude/exact_skills/docs/SKILL.md
@@ -51,8 +51,6 @@ note/{date}-{title}.md          # repoに紐づかない
 - `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
 - `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
 
-`ccs/*` は計算機分野、`ndc/*` は汎用知識、`tech/*` は実体（ツール+概念）。
-
 例: Hono の認証ミドルウェア比較ノートを永続化する場合
 
 ```yaml

--- a/dot_claude/exact_skills/issue/SKILL.md
+++ b/dot_claude/exact_skills/issue/SKILL.md
@@ -130,16 +130,11 @@ APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [
 
 ## セルフチェック
 
+手順に従えば満たされる項目は挙げない。判断を伴い漏れやすいもののみ:
+
 ```
-□ 類似issue/PRを open/closed 両方検索したか？
 □ 近接duplicate発見時にユーザーへ判断を仰いだか？
-□ CONTRIBUTING / CODE_OF_CONDUCT / SUPPORT を確認したか？
-□ template必須フィールドを埋めたか？
-□ 主張・修正内容にインライン出典を付けたか？
-□ 出典なしの情報に（未検証）を付けたか？
+□ community guidelines（CONTRIBUTING / CODE_OF_CONDUCT / SUPPORT）に抵触していないか？
 □ 1 issue = 1 concern か？
-□ draft を docs skill の規約で vault に保存したか？
 □ ユーザ確認を取ってから投稿したか？
-□ 投稿後、draft末尾にissue URLを追記したか？
-□ sub-issue紐付けの要否を判断したか？
 ```

--- a/dot_codex/exact_skills/docs/SKILL.md
+++ b/dot_codex/exact_skills/docs/SKILL.md
@@ -51,8 +51,6 @@ note/{date}-{title}.md          # repoに紐づかない
 - `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
 - `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
 
-`ccs/*` は計算機分野、`ndc/*` は汎用知識、`tech/*` は実体（ツール+概念）。
-
 例: Hono の認証ミドルウェア比較ノートを永続化する場合
 
 ```yaml

--- a/dot_codex/exact_skills/issue/SKILL.md
+++ b/dot_codex/exact_skills/issue/SKILL.md
@@ -130,16 +130,11 @@ APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [
 
 ## セルフチェック
 
+手順に従えば満たされる項目は挙げない。判断を伴い漏れやすいもののみ:
+
 ```
-□ 類似issue/PRを open/closed 両方検索したか？
 □ 近接duplicate発見時にユーザーへ判断を仰いだか？
-□ CONTRIBUTING / CODE_OF_CONDUCT / SUPPORT を確認したか？
-□ template必須フィールドを埋めたか？
-□ 主張・修正内容にインライン出典を付けたか？
-□ 出典なしの情報に（未検証）を付けたか？
+□ community guidelines（CONTRIBUTING / CODE_OF_CONDUCT / SUPPORT）に抵触していないか？
 □ 1 issue = 1 concern か？
-□ draft を docs skill の規約で vault に保存したか？
 □ ユーザ確認を取ってから投稿したか？
-□ 投稿後、draft末尾にissue URLを追記したか？
-□ sub-issue紐付けの要否を判断したか？
 ```

--- a/dot_cursor/exact_skills/docs/SKILL.md
+++ b/dot_cursor/exact_skills/docs/SKILL.md
@@ -51,8 +51,6 @@ note/{date}-{title}.md          # repoに紐づかない
 - `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
 - `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
 
-`ccs/*` は計算機分野、`ndc/*` は汎用知識、`tech/*` は実体（ツール+概念）。
-
 例: Hono の認証ミドルウェア比較ノートを永続化する場合
 
 ```yaml

--- a/dot_cursor/exact_skills/issue/SKILL.md
+++ b/dot_cursor/exact_skills/issue/SKILL.md
@@ -130,16 +130,11 @@ APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [
 
 ## セルフチェック
 
+手順に従えば満たされる項目は挙げない。判断を伴い漏れやすいもののみ:
+
 ```
-□ 類似issue/PRを open/closed 両方検索したか？
 □ 近接duplicate発見時にユーザーへ判断を仰いだか？
-□ CONTRIBUTING / CODE_OF_CONDUCT / SUPPORT を確認したか？
-□ template必須フィールドを埋めたか？
-□ 主張・修正内容にインライン出典を付けたか？
-□ 出典なしの情報に（未検証）を付けたか？
+□ community guidelines（CONTRIBUTING / CODE_OF_CONDUCT / SUPPORT）に抵触していないか？
 □ 1 issue = 1 concern か？
-□ draft を docs skill の規約で vault に保存したか？
 □ ユーザ確認を取ってから投稿したか？
-□ 投稿後、draft末尾にissue URLを追記したか？
-□ sub-issue紐付けの要否を判断したか？
 ```


### PR DESCRIPTION
Closes #25

## 変更内容

- `skills/docs/SKILL.md`: 「`ccs/*` は計算機分野、`ndc/*` は汎用知識、`tech/*` は実体（ツール+概念）」の行を削除。直前のタグ定義リスト（L46-52）の言い直しで情報の追加がないため
- `skills/issue/SKILL.md`: セルフチェックを 11 項目 → 4 項目に削減。手順に機械的に従えば満たされる復唱項目（open/closed 両方検索・template フィールド・出典付与・draft 保存・URL 追記・sub-issue 要否）を削り、判断を伴い漏れやすいもののみ残した:
  - 近接 duplicate 発見時のユーザーへの判断仰ぎ
  - community guidelines への抵触確認
  - 1 issue = 1 concern
  - 投稿前のユーザ承認

## スコープ外（issue 記載のとおり）

- 対象 3（tdd/SKILL.md 手順 1 の長文分解）は #23 の再設計 PR（#27）に吸収したため本 PR では扱わない
- 対象 4（pr-review/SKILL.md:35）は `allowed-tools` と重複するが、ドキュメントとしての明示を優先し残置

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xgFAbyYibkyY7UCnj5b53

---
_Generated by [Claude Code](https://claude.ai/code/session_017xgFAbyYibkyY7UCnj5b53)_