### PR TITLE
refactor(skills): フェーズ限定の詳細を references/ へ分割（progressive disclosure）

### DIFF
--- a/ai-agent-configs/skills/docs/SKILL.md
+++ b/ai-agent-configs/skills/docs/SKILL.md
@@ -37,35 +37,7 @@ note/{date}-{title}.md          # repoに紐づかない
 
 ### タグ
 
-必須:
-
-- `purpose/*` — 目的（`purpose/research`, `purpose/meeting`, `purpose/decision`, `purpose/comparison`, `purpose/draft` 等）
-
-該当時:
-
-- `tech/*` — 技術関連ノート。具体ツール（`tech/hono`）と概念（`tech/async`）の両方を拾う
-- `repo/*` — リポジトリ紐付き（`repo/{org}/{repo}`）
-
-永続知財として横断検索に乗せたい場合（長期参照する調査結果など）はさらに分野分類タグを付ける。流れていく系（draft・意思決定ログ・ミーティングメモ等）は不要:
-
-- `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
-- `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
-
-例: Hono の認証ミドルウェア比較ノートを永続化する場合
-
-```yaml
-tags:
-  - purpose/research
-  - purpose/comparison
-  - tech/hono
-  - tech/typescript
-  - tech/middleware
-  - tech/authentication
-  - ccs/security
-  - ccs/software
-  - ndc/007
-  - ndc/548
-```
+frontmatter に必ずタグを付ける。タグ体系（必須タグ・条件付きタグ・分野分類・記入例）: `references/tags.md`
 
 ### 関連ドキュメント
 

--- a/ai-agent-configs/skills/docs/references/tags.md
+++ b/ai-agent-configs/skills/docs/references/tags.md
@@ -1,0 +1,31 @@
+# タグ体系
+
+必須:
+
+- `purpose/*` — 目的（`purpose/research`, `purpose/meeting`, `purpose/decision`, `purpose/comparison`, `purpose/draft` 等）
+
+該当時:
+
+- `tech/*` — 技術関連ノート。具体ツール（`tech/hono`）と概念（`tech/async`）の両方を拾う
+- `repo/*` — リポジトリ紐付き（`repo/{org}/{repo}`）
+
+永続知財として横断検索に乗せたい場合（長期参照する調査結果など）はさらに分野分類タグを付ける。流れていく系（draft・意思決定ログ・ミーティングメモ等）は不要:
+
+- `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
+- `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
+
+例: Hono の認証ミドルウェア比較ノートを永続化する場合
+
+```yaml
+tags:
+  - purpose/research
+  - purpose/comparison
+  - tech/hono
+  - tech/typescript
+  - tech/middleware
+  - tech/authentication
+  - ccs/security
+  - ccs/software
+  - ndc/007
+  - ndc/548
+```

--- a/ai-agent-configs/skills/issue/SKILL.md
+++ b/ai-agent-configs/skills/issue/SKILL.md
@@ -43,18 +43,7 @@ confirm-before-run: true
 
 ### community guidelines
 
-投稿前に以下を確認:
-
-- `CONTRIBUTING.md`: issue起票の手順、必須情報、ラベル運用
-- `CODE_OF_CONDUCT.md`: 表現や対応の禁止事項
-- `SUPPORT.md` / `.github/SUPPORT.md`: 質問は Discussions や Stack Overflow へ誘導されていないか
-- `README` の contributing 節
-
-```bash
-gh api repos/{repo}/contents/CONTRIBUTING.md --jq .content | base64 -d
-```
-
-APIで取れない場合（大きなrepo・branchデフォルト違い等）は `/tmp/{repo-slug}/` に `gh repo clone` してローカルで読む。
+確認項目と取得コマンド: `references/guidelines-check.md`
 
 ガイドラインに抵触する可能性があれば draft作成前にユーザーへ相談する。
 
@@ -101,30 +90,7 @@ repo owner が自身のloginまたは所属orgに含まれるかで内部/外部
 | sub-issue紐付け | 投稿後 GitHub sub-issue API で親に紐付け | draft本文に parent URL 記載のみ |
 | 報告 | issue番号・URL + draftパス + 類似issueサマリ | draftパス + 投稿先repo + 類似issueサマリ + 手動投稿案内 |
 
-投稿コマンド:
-
-```bash
-gh issue create --repo {repo} \
-  --title "..." \
-  --body-file <(obsidian read vault=obsidian-vault path="{org}/note/{date}-{title}.md" | sed '/^---$/,/^---$/d') \
-  --label "..."
-```
-
-投稿後、draft 末尾に投稿URLを追記:
-
-```bash
-obsidian append vault=obsidian-vault \
-  path="{org}/note/{date}-{title}.md" \
-  content="\n\n---\nPosted: {issue-url}"
-```
-
-### 6-3. sub-issue紐付け（該当時）
-
-GitHub のsub-issue APIで紐付ける。`gh issue --help` で最新のサブコマンド対応を確認。
-
-一般的には `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues` で `sub_issue_id` を渡す。`sub_issue_id` は issue の **database id**（`gh api repos/{repo}/issues/{num} --jq .id`）で、node_id や issue number とは別物。
-
-APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [ ] #{child}` を追記する案をユーザーに提示する（自動編集はしない）。
+投稿・URL追記コマンドと sub-issue API の詳細（database id の注意含む）: `references/posting.md`
 
 ---
 

--- a/ai-agent-configs/skills/issue/references/guidelines-check.md
+++ b/ai-agent-configs/skills/issue/references/guidelines-check.md
@@ -1,0 +1,14 @@
+# community guidelines の確認項目
+
+投稿前に以下を確認:
+
+- `CONTRIBUTING.md`: issue起票の手順、必須情報、ラベル運用
+- `CODE_OF_CONDUCT.md`: 表現や対応の禁止事項
+- `SUPPORT.md` / `.github/SUPPORT.md`: 質問は Discussions や Stack Overflow へ誘導されていないか
+- `README` の contributing 節
+
+```bash
+gh api repos/{repo}/contents/CONTRIBUTING.md --jq .content | base64 -d
+```
+
+APIで取れない場合（大きなrepo・branchデフォルト違い等）は `/tmp/{repo-slug}/` に `gh repo clone` してローカルで読む。

--- a/ai-agent-configs/skills/issue/references/posting.md
+++ b/ai-agent-configs/skills/issue/references/posting.md
@@ -1,0 +1,26 @@
+# 投稿・sub-issue 紐付けコマンド
+
+## 投稿
+
+```bash
+gh issue create --repo {repo} \
+  --title "..." \
+  --body-file <(obsidian read vault=obsidian-vault path="{org}/note/{date}-{title}.md" | sed '/^---$/,/^---$/d') \
+  --label "..."
+```
+
+投稿後、draft 末尾に投稿URLを追記:
+
+```bash
+obsidian append vault=obsidian-vault \
+  path="{org}/note/{date}-{title}.md" \
+  content="\n\n---\nPosted: {issue-url}"
+```
+
+## sub-issue 紐付け（該当時）
+
+GitHub のsub-issue APIで紐付ける。`gh issue --help` で最新のサブコマンド対応を確認。
+
+一般的には `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues` で `sub_issue_id` を渡す。`sub_issue_id` は issue の **database id**（`gh api repos/{repo}/issues/{num} --jq .id`）で、node_id や issue number とは別物。
+
+APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [ ] #{child}` を追記する案をユーザーに提示する（自動編集はしない）。

--- a/dot_claude/exact_skills/docs/SKILL.md
+++ b/dot_claude/exact_skills/docs/SKILL.md
@@ -37,35 +37,7 @@ note/{date}-{title}.md          # repoに紐づかない
 
 ### タグ
 
-必須:
-
-- `purpose/*` — 目的（`purpose/research`, `purpose/meeting`, `purpose/decision`, `purpose/comparison`, `purpose/draft` 等）
-
-該当時:
-
-- `tech/*` — 技術関連ノート。具体ツール（`tech/hono`）と概念（`tech/async`）の両方を拾う
-- `repo/*` — リポジトリ紐付き（`repo/{org}/{repo}`）
-
-永続知財として横断検索に乗せたい場合（長期参照する調査結果など）はさらに分野分類タグを付ける。流れていく系（draft・意思決定ログ・ミーティングメモ等）は不要:
-
-- `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
-- `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
-
-例: Hono の認証ミドルウェア比較ノートを永続化する場合
-
-```yaml
-tags:
-  - purpose/research
-  - purpose/comparison
-  - tech/hono
-  - tech/typescript
-  - tech/middleware
-  - tech/authentication
-  - ccs/security
-  - ccs/software
-  - ndc/007
-  - ndc/548
-```
+frontmatter に必ずタグを付ける。タグ体系（必須タグ・条件付きタグ・分野分類・記入例）: `references/tags.md`
 
 ### 関連ドキュメント
 

--- a/dot_claude/exact_skills/docs/references/tags.md
+++ b/dot_claude/exact_skills/docs/references/tags.md
@@ -1,0 +1,31 @@
+# タグ体系
+
+必須:
+
+- `purpose/*` — 目的（`purpose/research`, `purpose/meeting`, `purpose/decision`, `purpose/comparison`, `purpose/draft` 等）
+
+該当時:
+
+- `tech/*` — 技術関連ノート。具体ツール（`tech/hono`）と概念（`tech/async`）の両方を拾う
+- `repo/*` — リポジトリ紐付き（`repo/{org}/{repo}`）
+
+永続知財として横断検索に乗せたい場合（長期参照する調査結果など）はさらに分野分類タグを付ける。流れていく系（draft・意思決定ログ・ミーティングメモ等）は不要:
+
+- `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
+- `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
+
+例: Hono の認証ミドルウェア比較ノートを永続化する場合
+
+```yaml
+tags:
+  - purpose/research
+  - purpose/comparison
+  - tech/hono
+  - tech/typescript
+  - tech/middleware
+  - tech/authentication
+  - ccs/security
+  - ccs/software
+  - ndc/007
+  - ndc/548
+```

--- a/dot_claude/exact_skills/issue/SKILL.md
+++ b/dot_claude/exact_skills/issue/SKILL.md
@@ -43,18 +43,7 @@ confirm-before-run: true
 
 ### community guidelines
 
-投稿前に以下を確認:
-
-- `CONTRIBUTING.md`: issue起票の手順、必須情報、ラベル運用
-- `CODE_OF_CONDUCT.md`: 表現や対応の禁止事項
-- `SUPPORT.md` / `.github/SUPPORT.md`: 質問は Discussions や Stack Overflow へ誘導されていないか
-- `README` の contributing 節
-
-```bash
-gh api repos/{repo}/contents/CONTRIBUTING.md --jq .content | base64 -d
-```
-
-APIで取れない場合（大きなrepo・branchデフォルト違い等）は `/tmp/{repo-slug}/` に `gh repo clone` してローカルで読む。
+確認項目と取得コマンド: `references/guidelines-check.md`
 
 ガイドラインに抵触する可能性があれば draft作成前にユーザーへ相談する。
 
@@ -101,30 +90,7 @@ repo owner が自身のloginまたは所属orgに含まれるかで内部/外部
 | sub-issue紐付け | 投稿後 GitHub sub-issue API で親に紐付け | draft本文に parent URL 記載のみ |
 | 報告 | issue番号・URL + draftパス + 類似issueサマリ | draftパス + 投稿先repo + 類似issueサマリ + 手動投稿案内 |
 
-投稿コマンド:
-
-```bash
-gh issue create --repo {repo} \
-  --title "..." \
-  --body-file <(obsidian read vault=obsidian-vault path="{org}/note/{date}-{title}.md" | sed '/^---$/,/^---$/d') \
-  --label "..."
-```
-
-投稿後、draft 末尾に投稿URLを追記:
-
-```bash
-obsidian append vault=obsidian-vault \
-  path="{org}/note/{date}-{title}.md" \
-  content="\n\n---\nPosted: {issue-url}"
-```
-
-### 6-3. sub-issue紐付け（該当時）
-
-GitHub のsub-issue APIで紐付ける。`gh issue --help` で最新のサブコマンド対応を確認。
-
-一般的には `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues` で `sub_issue_id` を渡す。`sub_issue_id` は issue の **database id**（`gh api repos/{repo}/issues/{num} --jq .id`）で、node_id や issue number とは別物。
-
-APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [ ] #{child}` を追記する案をユーザーに提示する（自動編集はしない）。
+投稿・URL追記コマンドと sub-issue API の詳細（database id の注意含む）: `references/posting.md`
 
 ---
 

--- a/dot_claude/exact_skills/issue/references/guidelines-check.md
+++ b/dot_claude/exact_skills/issue/references/guidelines-check.md
@@ -1,0 +1,14 @@
+# community guidelines の確認項目
+
+投稿前に以下を確認:
+
+- `CONTRIBUTING.md`: issue起票の手順、必須情報、ラベル運用
+- `CODE_OF_CONDUCT.md`: 表現や対応の禁止事項
+- `SUPPORT.md` / `.github/SUPPORT.md`: 質問は Discussions や Stack Overflow へ誘導されていないか
+- `README` の contributing 節
+
+```bash
+gh api repos/{repo}/contents/CONTRIBUTING.md --jq .content | base64 -d
+```
+
+APIで取れない場合（大きなrepo・branchデフォルト違い等）は `/tmp/{repo-slug}/` に `gh repo clone` してローカルで読む。

--- a/dot_claude/exact_skills/issue/references/posting.md
+++ b/dot_claude/exact_skills/issue/references/posting.md
@@ -1,0 +1,26 @@
+# 投稿・sub-issue 紐付けコマンド
+
+## 投稿
+
+```bash
+gh issue create --repo {repo} \
+  --title "..." \
+  --body-file <(obsidian read vault=obsidian-vault path="{org}/note/{date}-{title}.md" | sed '/^---$/,/^---$/d') \
+  --label "..."
+```
+
+投稿後、draft 末尾に投稿URLを追記:
+
+```bash
+obsidian append vault=obsidian-vault \
+  path="{org}/note/{date}-{title}.md" \
+  content="\n\n---\nPosted: {issue-url}"
+```
+
+## sub-issue 紐付け（該当時）
+
+GitHub のsub-issue APIで紐付ける。`gh issue --help` で最新のサブコマンド対応を確認。
+
+一般的には `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues` で `sub_issue_id` を渡す。`sub_issue_id` は issue の **database id**（`gh api repos/{repo}/issues/{num} --jq .id`）で、node_id や issue number とは別物。
+
+APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [ ] #{child}` を追記する案をユーザーに提示する（自動編集はしない）。

--- a/dot_codex/exact_skills/docs/SKILL.md
+++ b/dot_codex/exact_skills/docs/SKILL.md
@@ -37,35 +37,7 @@ note/{date}-{title}.md          # repoに紐づかない
 
 ### タグ
 
-必須:
-
-- `purpose/*` — 目的（`purpose/research`, `purpose/meeting`, `purpose/decision`, `purpose/comparison`, `purpose/draft` 等）
-
-該当時:
-
-- `tech/*` — 技術関連ノート。具体ツール（`tech/hono`）と概念（`tech/async`）の両方を拾う
-- `repo/*` — リポジトリ紐付き（`repo/{org}/{repo}`）
-
-永続知財として横断検索に乗せたい場合（長期参照する調査結果など）はさらに分野分類タグを付ける。流れていく系（draft・意思決定ログ・ミーティングメモ等）は不要:
-
-- `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
-- `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
-
-例: Hono の認証ミドルウェア比較ノートを永続化する場合
-
-```yaml
-tags:
-  - purpose/research
-  - purpose/comparison
-  - tech/hono
-  - tech/typescript
-  - tech/middleware
-  - tech/authentication
-  - ccs/security
-  - ccs/software
-  - ndc/007
-  - ndc/548
-```
+frontmatter に必ずタグを付ける。タグ体系（必須タグ・条件付きタグ・分野分類・記入例）: `references/tags.md`
 
 ### 関連ドキュメント
 

--- a/dot_codex/exact_skills/docs/references/tags.md
+++ b/dot_codex/exact_skills/docs/references/tags.md
@@ -1,0 +1,31 @@
+# タグ体系
+
+必須:
+
+- `purpose/*` — 目的（`purpose/research`, `purpose/meeting`, `purpose/decision`, `purpose/comparison`, `purpose/draft` 等）
+
+該当時:
+
+- `tech/*` — 技術関連ノート。具体ツール（`tech/hono`）と概念（`tech/async`）の両方を拾う
+- `repo/*` — リポジトリ紐付き（`repo/{org}/{repo}`）
+
+永続知財として横断検索に乗せたい場合（長期参照する調査結果など）はさらに分野分類タグを付ける。流れていく系（draft・意思決定ログ・ミーティングメモ等）は不要:
+
+- `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
+- `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
+
+例: Hono の認証ミドルウェア比較ノートを永続化する場合
+
+```yaml
+tags:
+  - purpose/research
+  - purpose/comparison
+  - tech/hono
+  - tech/typescript
+  - tech/middleware
+  - tech/authentication
+  - ccs/security
+  - ccs/software
+  - ndc/007
+  - ndc/548
+```

--- a/dot_codex/exact_skills/issue/SKILL.md
+++ b/dot_codex/exact_skills/issue/SKILL.md
@@ -43,18 +43,7 @@ confirm-before-run: true
 
 ### community guidelines
 
-投稿前に以下を確認:
-
-- `CONTRIBUTING.md`: issue起票の手順、必須情報、ラベル運用
-- `CODE_OF_CONDUCT.md`: 表現や対応の禁止事項
-- `SUPPORT.md` / `.github/SUPPORT.md`: 質問は Discussions や Stack Overflow へ誘導されていないか
-- `README` の contributing 節
-
-```bash
-gh api repos/{repo}/contents/CONTRIBUTING.md --jq .content | base64 -d
-```
-
-APIで取れない場合（大きなrepo・branchデフォルト違い等）は `/tmp/{repo-slug}/` に `gh repo clone` してローカルで読む。
+確認項目と取得コマンド: `references/guidelines-check.md`
 
 ガイドラインに抵触する可能性があれば draft作成前にユーザーへ相談する。
 
@@ -101,30 +90,7 @@ repo owner が自身のloginまたは所属orgに含まれるかで内部/外部
 | sub-issue紐付け | 投稿後 GitHub sub-issue API で親に紐付け | draft本文に parent URL 記載のみ |
 | 報告 | issue番号・URL + draftパス + 類似issueサマリ | draftパス + 投稿先repo + 類似issueサマリ + 手動投稿案内 |
 
-投稿コマンド:
-
-```bash
-gh issue create --repo {repo} \
-  --title "..." \
-  --body-file <(obsidian read vault=obsidian-vault path="{org}/note/{date}-{title}.md" | sed '/^---$/,/^---$/d') \
-  --label "..."
-```
-
-投稿後、draft 末尾に投稿URLを追記:
-
-```bash
-obsidian append vault=obsidian-vault \
-  path="{org}/note/{date}-{title}.md" \
-  content="\n\n---\nPosted: {issue-url}"
-```
-
-### 6-3. sub-issue紐付け（該当時）
-
-GitHub のsub-issue APIで紐付ける。`gh issue --help` で最新のサブコマンド対応を確認。
-
-一般的には `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues` で `sub_issue_id` を渡す。`sub_issue_id` は issue の **database id**（`gh api repos/{repo}/issues/{num} --jq .id`）で、node_id や issue number とは別物。
-
-APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [ ] #{child}` を追記する案をユーザーに提示する（自動編集はしない）。
+投稿・URL追記コマンドと sub-issue API の詳細（database id の注意含む）: `references/posting.md`
 
 ---
 

--- a/dot_codex/exact_skills/issue/references/guidelines-check.md
+++ b/dot_codex/exact_skills/issue/references/guidelines-check.md
@@ -1,0 +1,14 @@
+# community guidelines の確認項目
+
+投稿前に以下を確認:
+
+- `CONTRIBUTING.md`: issue起票の手順、必須情報、ラベル運用
+- `CODE_OF_CONDUCT.md`: 表現や対応の禁止事項
+- `SUPPORT.md` / `.github/SUPPORT.md`: 質問は Discussions や Stack Overflow へ誘導されていないか
+- `README` の contributing 節
+
+```bash
+gh api repos/{repo}/contents/CONTRIBUTING.md --jq .content | base64 -d
+```
+
+APIで取れない場合（大きなrepo・branchデフォルト違い等）は `/tmp/{repo-slug}/` に `gh repo clone` してローカルで読む。

--- a/dot_codex/exact_skills/issue/references/posting.md
+++ b/dot_codex/exact_skills/issue/references/posting.md
@@ -1,0 +1,26 @@
+# 投稿・sub-issue 紐付けコマンド
+
+## 投稿
+
+```bash
+gh issue create --repo {repo} \
+  --title "..." \
+  --body-file <(obsidian read vault=obsidian-vault path="{org}/note/{date}-{title}.md" | sed '/^---$/,/^---$/d') \
+  --label "..."
+```
+
+投稿後、draft 末尾に投稿URLを追記:
+
+```bash
+obsidian append vault=obsidian-vault \
+  path="{org}/note/{date}-{title}.md" \
+  content="\n\n---\nPosted: {issue-url}"
+```
+
+## sub-issue 紐付け（該当時）
+
+GitHub のsub-issue APIで紐付ける。`gh issue --help` で最新のサブコマンド対応を確認。
+
+一般的には `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues` で `sub_issue_id` を渡す。`sub_issue_id` は issue の **database id**（`gh api repos/{repo}/issues/{num} --jq .id`）で、node_id や issue number とは別物。
+
+APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [ ] #{child}` を追記する案をユーザーに提示する（自動編集はしない）。

--- a/dot_cursor/exact_skills/docs/SKILL.md
+++ b/dot_cursor/exact_skills/docs/SKILL.md
@@ -37,35 +37,7 @@ note/{date}-{title}.md          # repoに紐づかない
 
 ### タグ
 
-必須:
-
-- `purpose/*` — 目的（`purpose/research`, `purpose/meeting`, `purpose/decision`, `purpose/comparison`, `purpose/draft` 等）
-
-該当時:
-
-- `tech/*` — 技術関連ノート。具体ツール（`tech/hono`）と概念（`tech/async`）の両方を拾う
-- `repo/*` — リポジトリ紐付き（`repo/{org}/{repo}`）
-
-永続知財として横断検索に乗せたい場合（長期参照する調査結果など）はさらに分野分類タグを付ける。流れていく系（draft・意思決定ログ・ミーティングメモ等）は不要:
-
-- `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
-- `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
-
-例: Hono の認証ミドルウェア比較ノートを永続化する場合
-
-```yaml
-tags:
-  - purpose/research
-  - purpose/comparison
-  - tech/hono
-  - tech/typescript
-  - tech/middleware
-  - tech/authentication
-  - ccs/security
-  - ccs/software
-  - ndc/007
-  - ndc/548
-```
+frontmatter に必ずタグを付ける。タグ体系（必須タグ・条件付きタグ・分野分類・記入例）: `references/tags.md`
 
 ### 関連ドキュメント
 

--- a/dot_cursor/exact_skills/docs/references/tags.md
+++ b/dot_cursor/exact_skills/docs/references/tags.md
@@ -1,0 +1,31 @@
+# タグ体系
+
+必須:
+
+- `purpose/*` — 目的（`purpose/research`, `purpose/meeting`, `purpose/decision`, `purpose/comparison`, `purpose/draft` 等）
+
+該当時:
+
+- `tech/*` — 技術関連ノート。具体ツール（`tech/hono`）と概念（`tech/async`）の両方を拾う
+- `repo/*` — リポジトリ紐付き（`repo/{org}/{repo}`）
+
+永続知財として横断検索に乗せたい場合（長期参照する調査結果など）はさらに分野分類タグを付ける。流れていく系（draft・意思決定ログ・ミーティングメモ等）は不要:
+
+- `ndc/*` — 汎用分野分類。語彙: `~/.references/taxonomy/ndc.md`
+- `ccs/*` — 計算機分野の領域分類。語彙: `~/.references/taxonomy/ccs.md`
+
+例: Hono の認証ミドルウェア比較ノートを永続化する場合
+
+```yaml
+tags:
+  - purpose/research
+  - purpose/comparison
+  - tech/hono
+  - tech/typescript
+  - tech/middleware
+  - tech/authentication
+  - ccs/security
+  - ccs/software
+  - ndc/007
+  - ndc/548
+```

--- a/dot_cursor/exact_skills/issue/SKILL.md
+++ b/dot_cursor/exact_skills/issue/SKILL.md
@@ -43,18 +43,7 @@ confirm-before-run: true
 
 ### community guidelines
 
-投稿前に以下を確認:
-
-- `CONTRIBUTING.md`: issue起票の手順、必須情報、ラベル運用
-- `CODE_OF_CONDUCT.md`: 表現や対応の禁止事項
-- `SUPPORT.md` / `.github/SUPPORT.md`: 質問は Discussions や Stack Overflow へ誘導されていないか
-- `README` の contributing 節
-
-```bash
-gh api repos/{repo}/contents/CONTRIBUTING.md --jq .content | base64 -d
-```
-
-APIで取れない場合（大きなrepo・branchデフォルト違い等）は `/tmp/{repo-slug}/` に `gh repo clone` してローカルで読む。
+確認項目と取得コマンド: `references/guidelines-check.md`
 
 ガイドラインに抵触する可能性があれば draft作成前にユーザーへ相談する。
 
@@ -101,30 +90,7 @@ repo owner が自身のloginまたは所属orgに含まれるかで内部/外部
 | sub-issue紐付け | 投稿後 GitHub sub-issue API で親に紐付け | draft本文に parent URL 記載のみ |
 | 報告 | issue番号・URL + draftパス + 類似issueサマリ | draftパス + 投稿先repo + 類似issueサマリ + 手動投稿案内 |
 
-投稿コマンド:
-
-```bash
-gh issue create --repo {repo} \
-  --title "..." \
-  --body-file <(obsidian read vault=obsidian-vault path="{org}/note/{date}-{title}.md" | sed '/^---$/,/^---$/d') \
-  --label "..."
-```
-
-投稿後、draft 末尾に投稿URLを追記:
-
-```bash
-obsidian append vault=obsidian-vault \
-  path="{org}/note/{date}-{title}.md" \
-  content="\n\n---\nPosted: {issue-url}"
-```
-
-### 6-3. sub-issue紐付け（該当時）
-
-GitHub のsub-issue APIで紐付ける。`gh issue --help` で最新のサブコマンド対応を確認。
-
-一般的には `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues` で `sub_issue_id` を渡す。`sub_issue_id` は issue の **database id**（`gh api repos/{repo}/issues/{num} --jq .id`）で、node_id や issue number とは別物。
-
-APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [ ] #{child}` を追記する案をユーザーに提示する（自動編集はしない）。
+投稿・URL追記コマンドと sub-issue API の詳細（database id の注意含む）: `references/posting.md`
 
 ---
 

--- a/dot_cursor/exact_skills/issue/references/guidelines-check.md
+++ b/dot_cursor/exact_skills/issue/references/guidelines-check.md
@@ -1,0 +1,14 @@
+# community guidelines の確認項目
+
+投稿前に以下を確認:
+
+- `CONTRIBUTING.md`: issue起票の手順、必須情報、ラベル運用
+- `CODE_OF_CONDUCT.md`: 表現や対応の禁止事項
+- `SUPPORT.md` / `.github/SUPPORT.md`: 質問は Discussions や Stack Overflow へ誘導されていないか
+- `README` の contributing 節
+
+```bash
+gh api repos/{repo}/contents/CONTRIBUTING.md --jq .content | base64 -d
+```
+
+APIで取れない場合（大きなrepo・branchデフォルト違い等）は `/tmp/{repo-slug}/` に `gh repo clone` してローカルで読む。

--- a/dot_cursor/exact_skills/issue/references/posting.md
+++ b/dot_cursor/exact_skills/issue/references/posting.md
@@ -1,0 +1,26 @@
+# 投稿・sub-issue 紐付けコマンド
+
+## 投稿
+
+```bash
+gh issue create --repo {repo} \
+  --title "..." \
+  --body-file <(obsidian read vault=obsidian-vault path="{org}/note/{date}-{title}.md" | sed '/^---$/,/^---$/d') \
+  --label "..."
+```
+
+投稿後、draft 末尾に投稿URLを追記:
+
+```bash
+obsidian append vault=obsidian-vault \
+  path="{org}/note/{date}-{title}.md" \
+  content="\n\n---\nPosted: {issue-url}"
+```
+
+## sub-issue 紐付け（該当時）
+
+GitHub のsub-issue APIで紐付ける。`gh issue --help` で最新のサブコマンド対応を確認。
+
+一般的には `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues` で `sub_issue_id` を渡す。`sub_issue_id` は issue の **database id**（`gh api repos/{repo}/issues/{num} --jq .id`）で、node_id や issue number とは別物。
+
+APIが想定どおり動かない場合は、親issue本文の Tasklist に `- [ ] #{child}` を追記する案をユーザーに提示する（自動編集はしない）。


### PR DESCRIPTION
Closes #26

> [!NOTE]
> **#29 にスタックした PR です**（base = `claude/issue-25-skill-redundancy`）。同じファイル（issue/docs の SKILL.md）を編集するため、#29 を先にマージしてから本 PR の base を main に切り替えてマージしてください。

## 変更内容

study skill の `references/term-pages.md` と同じ分割パターンを issue / docs に適用し、skill 読み込み時のコンテキスト消費を削減した。SKILL.md 本体はフロー + 判断基準に絞り、特定フェーズでしか使わない詳細は参照時に読み込む。

- `skills/issue/references/posting.md` 新規: `gh issue create` の投稿コマンド、draft への URL 追記、sub-issue API の詳細（database id と node_id / issue number の区別）を移動
- `skills/issue/references/guidelines-check.md` 新規: CONTRIBUTING / CODE_OF_CONDUCT / SUPPORT の確認項目と取得コマンドを移動
- `skills/docs/references/tags.md` 新規: タグ体系（必須 / 条件付き / 分野分類 / 記入例）を移動
- 各 SKILL.md には 1 行の参照を残した（study/SKILL.md の既存パターンに準拠）。issue/SKILL.md の判断基準（duplicate 中断・内部/外部判定・1 issue = 1 concern・アクション表）は本文に残している

references/ は routes.txt の `sync` でディレクトリごと配布されるため、配布設定の変更は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xgFAbyYibkyY7UCnj5b53

---
_Generated by [Claude Code](https://claude.ai/code/session_017xgFAbyYibkyY7UCnj5b53)_